### PR TITLE
invalid-meta bootstrap-imagebox is missing "main" entry in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,6 +4,9 @@
   "authors": [
     "Weber Liu <weberliu@gmail.com>"
   ],
+  "main": [
+    "bootstrap-imagebox.js"
+  ],
   "description": "A image lightbox for bootstrap",
   "keywords": [
     "lightbox",

--- a/bower.json
+++ b/bower.json
@@ -25,6 +25,6 @@
     "tests"
   ],
   "dependencies": {
-    "bootstrap": "~3.3.4"
+    "bootstrap": "~3.3"
   }
 }


### PR DESCRIPTION
during bower update I got error, mentioed in a title. So added section to bower.json

Also changed bootstrap dependencies to stick to 3.3.\* version.
